### PR TITLE
Share underlying bytes instead of having an extra copy

### DIFF
--- a/src/main/scala/com/ironcorelabs/DocumentEncryptResult.scala
+++ b/src/main/scala/com/ironcorelabs/DocumentEncryptResult.scala
@@ -33,7 +33,7 @@ object DocumentEncryptResult {
     DocumentEncryptResult(
       DocumentId(der.getId.getId),
       DocumentName.fromJava(der.getName),
-      ByteVector.view(der.getEncryptedData),
+      ByteVector.view(underlyingBytes),
       der.getCreated,
       der.getLastUpdated,
       der.getChanged,

--- a/src/main/scala/com/ironcorelabs/DocumentEncryptUnmanagedResult.scala
+++ b/src/main/scala/com/ironcorelabs/DocumentEncryptUnmanagedResult.scala
@@ -28,8 +28,8 @@ object DocumentEncryptUnmanagedResult {
 
     DocumentEncryptUnmanagedResult(
       DocumentId(dder.getId.getId),
-      EncryptedData(ByteVector.view(dder.getEncryptedData))(underlyingDataBytes),
-      EncryptedDeks(ByteVector.view(dder.getEncryptedDeks))(underlyingDekBytes),
+      EncryptedData(ByteVector.view(underlyingDataBytes))(underlyingDataBytes),
+      EncryptedDeks(ByteVector.view(underlyingDekBytes))(underlyingDekBytes),
       dder.getChanged,
       dder.getErrors
     )


### PR DESCRIPTION
There were a couple cases where the underlying bytes weren't being shared. Fixed to share them and added tests to assert about it.