### PR TITLE
Return group needsRotation to admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.2
+
+- Add `groupGetMetadata()` to return group data for a given `GroupId`
+- Add `needsRotation` as an `Option[Boolean]` to `GroupMetaResult`
+
 ## 0.5.1
 
 - Update to ironoxide-java 0.6.1

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val root = (project in file(".")).settings(
   ),
   libraryDependencies ++= Seq(
     "org.scodec"       %% "scodec-bits"    % "1.1.12",
-    "com.ironcorelabs" % "ironoxide-java"  % "0.6.0",
+    "com.ironcorelabs" % "ironoxide-java"  % "0.6.1-SNAPSHOT",
     "org.typelevel"    %% "cats-effect"    % "2.0.0",
     "com.ironcorelabs" %% "cats-scalatest" % "2.4.1" % Test,
     "org.scalatest"    %% "scalatest"      % "3.0.8" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val root = (project in file(".")).settings(
     "org.scodec"       %% "scodec-bits"    % "1.1.12",
     "com.ironcorelabs" % "ironoxide-java"  % "0.6.2",
     "org.typelevel"    %% "cats-effect"    % "2.0.0",
-    "com.ironcorelabs" %% "cats-scalatest" % "2.4.1" % Test,
+    "com.ironcorelabs" %% "cats-scalatest" % "3.0.0" % Test,
     "org.scalatest"    %% "scalatest"      % "3.0.8" % Test
   )
 )

--- a/src/main/scala/com/ironcorelabs/GroupGetResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupGetResult.scala
@@ -1,0 +1,42 @@
+package com.ironcorelabs.scala.sdk
+
+import com.ironcorelabs.{sdk => jsdk}
+import java.{util => ju}
+
+/**
+ * Abbreviated group meta information.
+ */
+case class GroupGetResult(
+  id: GroupId,
+  name: Option[GroupName],
+  groupMasterPublicKey: PublicKey,
+  isAdmin: Boolean,
+  isMember: Boolean,
+  adminList: Option[List[UserId]],
+  memberList: Option[List[UserId]],
+  created: ju.Date,
+  lastUpdated: ju.Date,
+  needsRotation: Option[Boolean]
+)
+
+object GroupGetResult {
+  def apply(gmr: jsdk.GroupGetResult): GroupGetResult = {
+    val optName: Option[GroupName] = gmr.getName.toScala.map(n => GroupName(n.getName))
+    val optRotation = gmr.getNeedsRotation.toScala.map(_.getBoolean)
+    val optAdmins = gmr.getAdminList.toScala.map(_.getList.toList.map(id => UserId(id)))
+    val optMembers = gmr.getMemberList.toScala.map(_.getList.toList.map(id => UserId(id)))
+
+    GroupGetResult(
+      GroupId(gmr.getId.getId),
+      optName,
+      PublicKey(gmr.getGroupMasterPublicKey.asBytes),
+      gmr.isAdmin,
+      gmr.isMember,
+      optAdmins,
+      optMembers,
+      gmr.getCreated,
+      gmr.getLastUpdated,
+      optRotation
+    )
+  }
+}

--- a/src/main/scala/com/ironcorelabs/GroupGetResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupGetResult.scala
@@ -5,6 +5,17 @@ import java.{util => ju}
 
 /**
  * Group information
+ *
+ * @param id unique id of the group (within the segment)
+ * @param name optional group name
+ * @param groupMasterPublicKey public key of the group
+ * @param isAdmin true if the calling user is a group administrator
+ * @param isMember true if the calling user is a group member
+ * @param adminList None if the calling user is not in the group, else a list of group admin UserIds
+ * @param memberList None if the calling user is not in the group, else a list of group member UserIds
+ * @param created date and time when the group was created
+ * @param updated date and time when the group was last updated
+ * @param needsRotation None if the calling user is not a group admin, else a boolean of if the group private key needs rotation
  */
 case class GroupGetResult(
   id: GroupId,
@@ -20,22 +31,22 @@ case class GroupGetResult(
 )
 
 object GroupGetResult {
-  def apply(gmr: jsdk.GroupGetResult): GroupGetResult = {
-    val optName: Option[GroupName] = gmr.getName.toScala.map(n => GroupName(n.getName))
-    val optRotation = gmr.getNeedsRotation.toScala.map(_.getBoolean)
-    val optAdmins = gmr.getAdminList.toScala.map(_.getList.toList.map(id => UserId(id)))
-    val optMembers = gmr.getMemberList.toScala.map(_.getList.toList.map(id => UserId(id)))
+  def apply(ggr: jsdk.GroupGetResult): GroupGetResult = {
+    val optName: Option[GroupName] = ggr.getName.toScala.map(n => GroupName(n.getName))
+    val optRotation = ggr.getNeedsRotation.toScala.map(_.getBoolean)
+    val optAdmins = ggr.getAdminList.toScala.map(_.getList.toList.map(UserId(_)))
+    val optMembers = ggr.getMemberList.toScala.map(_.getList.toList.map(UserId(_)))
 
     GroupGetResult(
-      GroupId(gmr.getId.getId),
+      GroupId(ggr.getId.getId),
       optName,
-      PublicKey(gmr.getGroupMasterPublicKey.asBytes),
-      gmr.isAdmin,
-      gmr.isMember,
+      PublicKey(ggr.getGroupMasterPublicKey.asBytes),
+      ggr.isAdmin,
+      ggr.isMember,
       optAdmins,
       optMembers,
-      gmr.getCreated,
-      gmr.getLastUpdated,
+      ggr.getCreated,
+      ggr.getLastUpdated,
       optRotation
     )
   }

--- a/src/main/scala/com/ironcorelabs/GroupGetResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupGetResult.scala
@@ -7,7 +7,7 @@ import java.{util => ju}
  * Group information
  *
  * @param id unique id of the group (within the segment)
- * @param name optional group name
+ * @param name None if the group has no name, else the group's name
  * @param groupMasterPublicKey public key of the group
  * @param isAdmin true if the calling user is a group administrator
  * @param isMember true if the calling user is a group member
@@ -15,7 +15,7 @@ import java.{util => ju}
  * @param memberList None if the calling user is not in the group, else a list of group member UserIds
  * @param created date and time when the group was created
  * @param updated date and time when the group was last updated
- * @param needsRotation None if the calling user is not a group admin, else a boolean of if the group private key needs rotation
+ * @param needsRotation None if the calling user is not a group admin, else a boolean of if the group's private key needs rotation
  */
 case class GroupGetResult(
   id: GroupId,

--- a/src/main/scala/com/ironcorelabs/GroupGetResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupGetResult.scala
@@ -4,7 +4,7 @@ import com.ironcorelabs.{sdk => jsdk}
 import java.{util => ju}
 
 /**
- * Abbreviated group meta information.
+ * Group information
  */
 case class GroupGetResult(
   id: GroupId,

--- a/src/main/scala/com/ironcorelabs/GroupMetaResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupMetaResult.scala
@@ -12,13 +12,23 @@ case class GroupMetaResult(
   isAdmin: Boolean,
   isMember: Boolean,
   created: ju.Date,
-  lastUpdated: ju.Date
+  lastUpdated: ju.Date,
+  needsRotation: Option[Boolean]
 )
 
 object GroupMetaResult {
   def apply(gmr: jsdk.GroupMetaResult): GroupMetaResult = {
     val optName: Option[GroupName] = gmr.getName.toScala.map(n => GroupName(n.getName))
+    val optRotation = gmr.getNeedsRotation.toScala.map(_.getBoolean)
 
-    GroupMetaResult(GroupId(gmr.getId.getId), optName, gmr.isAdmin, gmr.isMember, gmr.getCreated, gmr.getLastUpdated)
+    GroupMetaResult(
+      GroupId(gmr.getId.getId),
+      optName,
+      gmr.isAdmin,
+      gmr.isMember,
+      gmr.getCreated,
+      gmr.getLastUpdated,
+      optRotation
+    )
   }
 }

--- a/src/main/scala/com/ironcorelabs/GroupMetaResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupMetaResult.scala
@@ -5,6 +5,14 @@ import java.{util => ju}
 
 /**
  * Abbreviated group meta information.
+ *
+ * @param id unique id of the group (within the segment)
+ * @param name None if the group has no name, else the group's name
+ * @param isAdmin true if the calling user is a group administrator
+ * @param isMember true if the calling user is a group member
+ * @param created date and time when the group was created
+ * @param lastUpdated date and time when the group was last updated
+ * @param needsRotation None if the calling user is not a group admin, else a boolean of if the group's private key needs rotation
  */
 case class GroupMetaResult(
   id: GroupId,

--- a/src/main/scala/com/ironcorelabs/IronSdk.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdk.scala
@@ -50,6 +50,9 @@ trait IronSdk[F[_]] {
    */
   def groupCreate(options: GroupCreateOpts): F[GroupMetaResult]
 
+  //TODO: docs
+  def groupGetMetadata(id: GroupId): F[GroupGetResult]
+
   /**
    * Create a new user within the IronCore system.
    *

--- a/src/main/scala/com/ironcorelabs/IronSdk.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdk.scala
@@ -50,11 +50,16 @@ trait IronSdk[F[_]] {
    */
   def groupCreate(options: GroupCreateOpts): F[GroupMetaResult]
 
-  //TODO: docs
+  /**
+   * Gets the full metadata for a specific group given its ID.
+   *
+   * @param id unique id of the group to retrieve
+   * @return details about the requested group
+   */
   def groupGetMetadata(id: GroupId): F[GroupGetResult]
 
   /**
-   * Create a new user within the IronCore system.
+   * Creates a new user within the IronCore system.
    *
    * @param jwt valid IronCore or Auth0 JWT
    * @param password password used to encrypt and escrow the user's private master key

--- a/src/main/scala/com/ironcorelabs/IronSdkFuture.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdkFuture.scala
@@ -10,6 +10,8 @@ case class IronSdkFuture(deviceContext: DeviceContext) extends IronSdk[Future] {
   def groupCreate(options: GroupCreateOpts): Future[GroupMetaResult] =
     underlying.groupCreate(options).unsafeToFuture
 
+  def groupGetMetadata(id: GroupId): Future[GroupGetResult] = underlying.groupGetMetadata(id).unsafeToFuture
+
   def documentEncrypt(data: ByteVector, options: DocumentEncryptOpts): Future[DocumentEncryptResult] =
     underlying.documentEncrypt(data, options).unsafeToFuture
 

--- a/src/main/scala/com/ironcorelabs/IronSdkSync.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdkSync.scala
@@ -13,6 +13,12 @@ case class IronSdkSync[F[_]](deviceContext: DeviceContext)(implicit syncF: Sync[
       result   <- underlying.map(_.groupCreate(javaOpts))
     } yield GroupMetaResult(result)
 
+  def groupGetMetadata(id: GroupId): F[GroupGetResult] =
+    for {
+      javaId <- id.toJava
+      result <- underlying.map(_.groupGetMetadata(javaId))
+    } yield GroupGetResult(result)
+
   def documentEncrypt(data: ByteVector, options: DocumentEncryptOpts): F[DocumentEncryptResult] =
     for {
       javaOpts <- options.toJava

--- a/src/test/scala/ironoxide/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/FullIntegrationTest.scala
@@ -2,11 +2,11 @@ package ironoxide
 
 import scodec.bits.ByteVector
 import com.ironcorelabs.scala.sdk._
-import org.scalatest.{AsyncWordSpec, Matchers}
+import org.scalatest.{AsyncWordSpec, Matchers, OptionValues}
 import cats.scalatest.EitherValues
 import cats.effect.IO
 
-class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues {
+class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues with OptionValues {
   try {
     java.lang.System.loadLibrary("ironoxide_java")
   } catch {
@@ -84,11 +84,11 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
       groupGetResult.name.get.name shouldBe "a name"
       groupGetResult.isAdmin shouldBe true
       groupGetResult.isMember shouldBe true
-      groupGetResult.adminList shouldBe Some(List(primaryTestUserId))
-      groupGetResult.memberList shouldBe Some(List(primaryTestUserId))
+      groupGetResult.adminList.value shouldBe List(primaryTestUserId)
+      groupGetResult.memberList.value shouldBe List(primaryTestUserId)
       groupGetResult.created should not be null
       groupGetResult.lastUpdated shouldBe groupGetResult.created
-      groupGetResult.needsRotation shouldBe Some(false)
+      groupGetResult.needsRotation.value shouldBe false
     }
     "Fail for invalid group id" in {
       val sdk = IronSdkSync[IO](deviceContext)

--- a/src/test/scala/ironoxide/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/FullIntegrationTest.scala
@@ -90,6 +90,11 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
       groupGetResult.lastUpdated shouldBe groupGetResult.created
       groupGetResult.needsRotation shouldBe Some(false)
     }
+    "Fail for invalid group id" in {
+      val sdk = IronSdkSync[IO](deviceContext)
+      val maybeGroupGetResult = sdk.groupGetMetadata(GroupId("tsp")).attempt.unsafeRunSync
+      maybeGroupGetResult.isLeft shouldBe true
+    }
   }
 
   "DeviceContext" should {

--- a/src/test/scala/ironoxide/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/FullIntegrationTest.scala
@@ -72,6 +72,7 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
       groupCreateResult.isMember shouldBe true
       groupCreateResult.created should not be null
       groupCreateResult.lastUpdated shouldBe groupCreateResult.created
+      groupCreateResult.needsRotation shouldBe Some(false)
     }
   }
 


### PR DESCRIPTION
- Added `needsRotation` as an `Option[Boolean]` to `GroupMetaResult`
- Added `GroupGetResult` and `groupGetMetadata()`
- Added test for `needsRotation` on `groupCreate()`
- Added test for `groupGetMetadata()`

TODO:
- [x] Depend on released ironoxide-scala