### PR TITLE
Add and remove group members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3
+
+- Add `groupAddMembers()` and `groupRemoveMembers()` to add/remove group members.
+
 ## 0.5.2
 
 - Add `groupGetMetadata()` to return group data for a given `GroupId`

--- a/src/main/scala/com/ironcorelabs/GroupAccessEditErr.scala
+++ b/src/main/scala/com/ironcorelabs/GroupAccessEditErr.scala
@@ -1,0 +1,6 @@
+package com.ironcorelabs.scala.sdk
+
+case class GroupAccessEditErr(
+  user: UserId,
+  error: String
+)

--- a/src/main/scala/com/ironcorelabs/GroupAccessEditResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupAccessEditResult.scala
@@ -11,6 +11,6 @@ object GroupAccessEditResult {
   def apply(gaer: jsdk.GroupAccessEditResult): GroupAccessEditResult =
     GroupAccessEditResult(
       gaer.getSucceeded.map(id => UserId(id.getId)).toList,
-      gaer.getFailed.map(err => GroupAccessEditErr(UserId(err.getUser.toString), err.getError)).toList
+      gaer.getFailed.map(err => GroupAccessEditErr(UserId(err.getUser), err.getError)).toList
     )
 }

--- a/src/main/scala/com/ironcorelabs/GroupAccessEditResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupAccessEditResult.scala
@@ -1,0 +1,16 @@
+package com.ironcorelabs.scala.sdk
+
+import com.ironcorelabs.{sdk => jsdk}
+
+case class GroupAccessEditResult(
+  succeeded: List[UserId],
+  failed: List[GroupAccessEditErr]
+)
+
+object GroupAccessEditResult {
+  def apply(gaer: jsdk.GroupAccessEditResult): GroupAccessEditResult =
+    GroupAccessEditResult(
+      gaer.getSucceeded.map(id => UserId(id.getId)).toList,
+      gaer.getFailed.map(err => GroupAccessEditErr(UserId(err.getUser.toString), err.getError)).toList
+    )
+}

--- a/src/main/scala/com/ironcorelabs/IronSdk.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdk.scala
@@ -51,6 +51,24 @@ trait IronSdk[F[_]] {
   def groupCreate(options: GroupCreateOpts): F[GroupMetaResult]
 
   /**
+   * Add a list of users as members of a group.
+   *
+   * @param id      id of the group to add members to
+   * @param users   the list of users thet will be added to the group as members
+   * @return all the users that were added and all the users that were not added with the reason they were not
+   */
+  def groupAddMembers(id: GroupId, users: List[UserId]): F[GroupAccessEditResult]
+
+  /**
+   * Remove a list of users as members from the group.
+   *
+   * @param id          id of the group to remove members from
+   * @param userRevokes list of user ids to remove as members
+   * @return list of users that were removed and the users that failed to be removed with the reason they were not
+   */
+  def groupRemoveMembers(id: GroupId, userRevokes: List[UserId]): F[GroupAccessEditResult]
+
+  /**
    * Gets the full metadata for a specific group given its ID.
    *
    * @param id unique id of the group to retrieve

--- a/src/main/scala/com/ironcorelabs/IronSdkFuture.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdkFuture.scala
@@ -10,6 +10,12 @@ case class IronSdkFuture(deviceContext: DeviceContext) extends IronSdk[Future] {
   def groupCreate(options: GroupCreateOpts): Future[GroupMetaResult] =
     underlying.groupCreate(options).unsafeToFuture
 
+  def groupAddMembers(id: GroupId, users: List[UserId]): Future[GroupAccessEditResult] =
+    underlying.groupAddMembers(id, users).unsafeToFuture
+
+  def groupRemoveMembers(id: GroupId, userRevokes: List[UserId]): Future[GroupAccessEditResult] =
+    underlying.groupRemoveMembers(id, userRevokes).unsafeToFuture
+
   def groupGetMetadata(id: GroupId): Future[GroupGetResult] = underlying.groupGetMetadata(id).unsafeToFuture
 
   def documentEncrypt(data: ByteVector, options: DocumentEncryptOpts): Future[DocumentEncryptResult] =

--- a/src/main/scala/com/ironcorelabs/IronSdkSync.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdkSync.scala
@@ -13,6 +13,22 @@ case class IronSdkSync[F[_]](deviceContext: DeviceContext)(implicit syncF: Sync[
       result   <- underlying.map(_.groupCreate(javaOpts))
     } yield GroupMetaResult(result)
 
+  def groupAddMembers(id: GroupId, users: List[UserId]): F[GroupAccessEditResult] =
+    for {
+      javaId        <- id.toJava
+      javaUsersList <- users.traverse(_.toJava)
+      javaUsersArray = javaUsersList.toArray[com.ironcorelabs.sdk.UserId]
+      result <- underlying.map(_.groupAddMembers(javaId, javaUsersArray))
+    } yield GroupAccessEditResult(result)
+
+  def groupRemoveMembers(id: GroupId, userRevokes: List[UserId]): F[GroupAccessEditResult] =
+    for {
+      javaId        <- id.toJava
+      javaUsersList <- userRevokes.traverse(_.toJava)
+      javaUsersArray = javaUsersList.toArray[com.ironcorelabs.sdk.UserId]
+      result <- underlying.map(_.groupRemoveMembers(javaId, javaUsersArray))
+    } yield GroupAccessEditResult(result)
+
   def groupGetMetadata(id: GroupId): F[GroupGetResult] =
     for {
       javaId <- id.toJava

--- a/src/test/scala/ironoxide/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/FullIntegrationTest.scala
@@ -81,9 +81,10 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
       val maybeAddMembersResult = sdk.groupAddMembers(GroupId("kumquat"), Nil).attempt.unsafeRunSync
       maybeAddMembersResult.isLeft shouldBe true
     }
-    "Fail for adding an existing member" in {
+    "Succeed in the call, but fail to add an existing member" in {
       val sdk = IronSdkSync[IO](deviceContext)
       val addMembersResult = sdk.groupAddMembers(validGroupId, List(primaryTestUserId)).attempt.unsafeRunSync.value
+      addMembersResult.failed.length shouldBe 1
       addMembersResult.failed.head.error should include("User was already a member")
     }
     "Fail for nonexistent UserId" in {
@@ -99,16 +100,19 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
       val maybeRemoveMembersResult = sdk.groupRemoveMembers(GroupId("icl"), Nil).attempt.unsafeRunSync
       maybeRemoveMembersResult.isLeft shouldBe true
     }
-    "Fail for nonexistent UserId" in {
+    "Succeed in the call, but fail to remove a nonexistent UserId" in {
       val sdk = IronSdkSync[IO](deviceContext)
-      val maybeRemoveMembersResult =
-        sdk.groupRemoveMembers(validGroupId, List(UserId("tony"))).attempt.unsafeRunSync
-      maybeRemoveMembersResult.value.failed.head.error should include("could not be removed")
+      val removeMembersResult =
+        sdk.groupRemoveMembers(validGroupId, List(UserId("tony"))).attempt.unsafeRunSync.value
+      removeMembersResult.failed.length shouldBe 1
+      removeMembersResult.failed.head.error should include("could not be removed")
     }
     "succeed for valid GroupId/UserId" in {
       val sdk = IronSdkSync[IO](deviceContext)
-      val maybeRemoveMembersResult = sdk.groupRemoveMembers(validGroupId, List(primaryTestUserId)).attempt.unsafeRunSync
-      maybeRemoveMembersResult.value.succeeded.head shouldBe primaryTestUserId
+      val removeMembersResult =
+        sdk.groupRemoveMembers(validGroupId, List(primaryTestUserId)).attempt.unsafeRunSync.value
+      removeMembersResult.succeeded.length shouldBe 1
+      removeMembersResult.succeeded.head shouldBe primaryTestUserId
     }
   }
 
@@ -116,6 +120,7 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
     "succeed for valid UserId" in {
       val sdk = IronSdkSync[IO](deviceContext)
       val addMembersResult = sdk.groupAddMembers(validGroupId, List(primaryTestUserId)).attempt.unsafeRunSync.value
+      addMembersResult.succeeded.length shouldBe 1
       addMembersResult.succeeded.head shouldBe primaryTestUserId
     }
   }


### PR DESCRIPTION
- Added `groupAddMembers()` to add a list of `UserIds` to a given `GroupId`
- Added `groupRemoveMembers()` to remove a list of `UserIds` to a given `GroupId`
- Added tests that remove the primary user as a group member, then re-add them as a member