### PR TITLE
Add and remove group admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.5.3
 
+- Update to ironoxide-java 0.7.0
 - Add `groupAddMembers()` and `groupRemoveMembers()` to add/remove group members.
+- Add `groupAddAdmins()` and `groupRemoveAdmins()` to add/remove group admins.
 
 ## 0.5.2
 

--- a/src/main/scala/com/ironcorelabs/DeviceId.scala
+++ b/src/main/scala/com/ironcorelabs/DeviceId.scala
@@ -3,6 +3,9 @@ package com.ironcorelabs.scala.sdk
 import cats.effect.Sync
 import com.ironcorelabs.{sdk => jsdk}
 
+/**
+ * ID of a device. Device IDs are numeric and will always be greater than 0.
+ */
 case class DeviceId(id: Long) {
   private[sdk] def toJava[F[_]](implicit syncF: Sync[F]): F[jsdk.DeviceId] = syncF.delay(jsdk.DeviceId.validate(id))
 }

--- a/src/main/scala/com/ironcorelabs/GroupAccessEditErr.scala
+++ b/src/main/scala/com/ironcorelabs/GroupAccessEditErr.scala
@@ -2,6 +2,9 @@ package com.ironcorelabs.scala.sdk
 
 import com.ironcorelabs.{sdk => jsdk}
 
+/**
+ * A failure to edit a group's administrator or membership lists
+ */
 case class GroupAccessEditErr(
   user: UserId,
   error: String

--- a/src/main/scala/com/ironcorelabs/GroupAccessEditErr.scala
+++ b/src/main/scala/com/ironcorelabs/GroupAccessEditErr.scala
@@ -3,7 +3,7 @@ package com.ironcorelabs.scala.sdk
 import com.ironcorelabs.{sdk => jsdk}
 
 /**
- * A failure to edit a group's administrator or membership lists
+ * Failure to edit a group's administrator or membership lists
  */
 case class GroupAccessEditErr(
   user: UserId,

--- a/src/main/scala/com/ironcorelabs/GroupAccessEditResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupAccessEditResult.scala
@@ -4,6 +4,9 @@ import com.ironcorelabs.{sdk => jsdk}
 import cats.implicits._
 import cats.effect.Sync
 
+/**
+ * Result from requesting changes to a group's membership or administrators. Partial success is supported.
+ */
 case class GroupAccessEditResult(
   succeeded: List[UserId],
   failed: List[GroupAccessEditErr]

--- a/src/main/scala/com/ironcorelabs/GroupAccessEditResult.scala
+++ b/src/main/scala/com/ironcorelabs/GroupAccessEditResult.scala
@@ -28,6 +28,6 @@ object GroupAccessEditResult {
       javaId        <- id.toJava
       javaUsersList <- users.traverse(_.toJava)
       javaUsersArray = javaUsersList.toArray[com.ironcorelabs.sdk.UserId]
-      result = fn(javaId, javaUsersArray)
+      result <- syncF.delay(fn(javaId, javaUsersArray))
     } yield GroupAccessEditResult(result)
 }

--- a/src/main/scala/com/ironcorelabs/IronSdk.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdk.scala
@@ -72,7 +72,7 @@ trait IronSdk[F[_]] {
    * Add a list of users as admins of a group.
    *
    * @param id      id of the group to add admins to
-   * @param users   the list of users thet will be added to the group as admins
+   * @param users   the list of users that will be added to the group as admins
    * @return all the users that were added and all the users that were not added with the reason they were not
    */
   def groupAddAdmins(id: GroupId, users: List[UserId]): F[GroupAccessEditResult]

--- a/src/main/scala/com/ironcorelabs/IronSdk.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdk.scala
@@ -69,6 +69,24 @@ trait IronSdk[F[_]] {
   def groupRemoveMembers(id: GroupId, userRevokes: List[UserId]): F[GroupAccessEditResult]
 
   /**
+   * Add a list of users as admins of a group.
+   *
+   * @param id      id of the group to add admins to
+   * @param users   the list of users thet will be added to the group as admins
+   * @return all the users that were added and all the users that were not added with the reason they were not
+   */
+  def groupAddAdmins(id: GroupId, users: List[UserId]): F[GroupAccessEditResult]
+
+  /**
+   * Remove a list of users as admins from the group.
+   *
+   * @param id          id of the group to remove admins from
+   * @param userRevokes list of user ids to remove as admins
+   * @return list of users that were removed and the users that failed to be removed with the reason they were not
+   */
+  def groupRemoveAdmins(id: GroupId, userRevokes: List[UserId]): F[GroupAccessEditResult]
+
+  /**
    * Gets the full metadata for a specific group given its ID.
    *
    * @param id unique id of the group to retrieve

--- a/src/main/scala/com/ironcorelabs/IronSdkFuture.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdkFuture.scala
@@ -16,6 +16,12 @@ case class IronSdkFuture(deviceContext: DeviceContext) extends IronSdk[Future] {
   def groupRemoveMembers(id: GroupId, userRevokes: List[UserId]): Future[GroupAccessEditResult] =
     underlying.groupRemoveMembers(id, userRevokes).unsafeToFuture
 
+  def groupAddAdmins(id: GroupId, users: List[UserId]): Future[GroupAccessEditResult] =
+    underlying.groupAddAdmins(id, users).unsafeToFuture
+
+  def groupRemoveAdmins(id: GroupId, userRevokes: List[UserId]): Future[GroupAccessEditResult] =
+    underlying.groupRemoveAdmins(id, userRevokes).unsafeToFuture
+
   def groupGetMetadata(id: GroupId): Future[GroupGetResult] = underlying.groupGetMetadata(id).unsafeToFuture
 
   def documentEncrypt(data: ByteVector, options: DocumentEncryptOpts): Future[DocumentEncryptResult] =

--- a/src/main/scala/com/ironcorelabs/UserCreateOpts.scala
+++ b/src/main/scala/com/ironcorelabs/UserCreateOpts.scala
@@ -3,6 +3,11 @@ package com.ironcorelabs.scala.sdk
 import cats.effect.Sync
 import com.ironcorelabs.{sdk => jsdk}
 
+/**
+ * Options that can be specified creating a user.
+ *
+ * @param needsRotation whether the created user needs their private key rotated
+ */
 case class UserCreateOpts(needsRotation: Boolean) {
   private[sdk] def toJava[F[_]](implicit syncF: Sync[F]): F[jsdk.UserCreateOpts] =
     syncF.delay(jsdk.UserCreateOpts.create(needsRotation))

--- a/src/test/scala/ironoxide/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/FullIntegrationTest.scala
@@ -144,6 +144,28 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
     }
   }
 
+  "Group Remove Admins" should {
+    "fail for nonexistent GroupId" in {
+      val sdk = IronSdkSync[IO](deviceContext)
+      val maybeRemoveAdminsResult = sdk.groupRemoveAdmins(GroupId("notarealgroup"), Nil).attempt.unsafeRunSync
+      maybeRemoveAdminsResult.isLeft shouldBe true
+    }
+    "Succeed in the call, but fail to remove a nonexistent UserId" in {
+      val sdk = IronSdkSync[IO](deviceContext)
+      val removeAdminsResult =
+        sdk.groupRemoveAdmins(validGroupId, List(UserId("tony"))).attempt.unsafeRunSync.value
+      removeAdminsResult.failed.length shouldBe 1
+      removeAdminsResult.failed.head.error should include("could not be removed")
+    }
+    "fail to remove sole group admin" in {
+      val sdk = IronSdkSync[IO](deviceContext)
+      val removeAdminsResult =
+        sdk.groupRemoveAdmins(validGroupId, List(primaryTestUserId)).attempt.unsafeRunSync.value
+      removeAdminsResult.failed.length shouldBe 1
+      removeAdminsResult.failed.head.error should include("could not be removed")
+    }
+  }
+
   "Group Get" should {
     "Return data for valid group admin" in {
       val sdk = IronSdkSync[IO](deviceContext)

--- a/src/test/scala/ironoxide/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/FullIntegrationTest.scala
@@ -125,6 +125,25 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
     }
   }
 
+  "Group Add Admins" should {
+    "Fail for nonexistent GroupId" in {
+      val sdk = IronSdkSync[IO](deviceContext)
+      val maybeAddAdminsResult = sdk.groupAddAdmins(GroupId("tony"), Nil).attempt.unsafeRunSync
+      maybeAddAdminsResult.isLeft shouldBe true
+    }
+    "Succeed in the call, but fail to add an existing member" in {
+      val sdk = IronSdkSync[IO](deviceContext)
+      val addAdminsResult = sdk.groupAddAdmins(validGroupId, List(primaryTestUserId)).attempt.unsafeRunSync.value
+      addAdminsResult.failed.length shouldBe 1
+      addAdminsResult.failed.head.error should include("User was already an admin")
+    }
+    "Fail for nonexistent UserId" in {
+      val sdk = IronSdkSync[IO](deviceContext)
+      val maybeAddAdminsResult = sdk.groupAddAdmins(validGroupId, List(UserId("steve"))).attempt.unsafeRunSync
+      maybeAddAdminsResult.isLeft shouldBe true
+    }
+  }
+
   "Group Get" should {
     "Return data for valid group admin" in {
       val sdk = IronSdkSync[IO](deviceContext)


### PR DESCRIPTION
- Added `groupAddAdmins()` to add a list of `UserIds` as admins to a given `GroupId`
- Added `groupRemoveAdmins()` to remove a list of admin `UserIds` from a given `GroupId`
- Added new constructor to `GroupAccessEditResult` to reduce code duplication in IronSdkSync