### PR TITLE
Add needsRotation to GroupCreateOpts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0
+
+- Update to ironoxide-java 0.8.0
+- Add `needsRotation` to `GroupCreateOpts` to specify whether a group needs its private key rotated on creation.
+
 ## 0.5.3
 
 - Update to ironoxide-java 0.7.0

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val root = (project in file(".")).settings(
   ),
   libraryDependencies ++= Seq(
     "org.scodec"       %% "scodec-bits"    % "1.1.12",
-    "com.ironcorelabs" % "ironoxide-java"  % "0.7.2",
+    "com.ironcorelabs" % "ironoxide-java"  % "0.7.3-SNAPSHOT",
     "org.typelevel"    %% "cats-effect"    % "2.0.0",
     "com.ironcorelabs" %% "cats-scalatest" % "3.0.0" % Test,
     "org.scalatest"    %% "scalatest"      % "3.0.8" % Test
@@ -41,6 +41,7 @@ scalacOptions in (Compile, console) ~= {
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
 fork in Test := true
+envVars in Test := Map("IRONCORE_ENV" -> "stage")
 
 licenses := Seq("AGPL-3.0" -> url("https://www.gnu.org/licenses/agpl-3.0.txt"))
 // Add the default sonatype repository setting

--- a/src/main/scala/com/ironcorelabs/GroupCreateOpts.scala
+++ b/src/main/scala/com/ironcorelabs/GroupCreateOpts.scala
@@ -10,22 +10,24 @@ import com.ironcorelabs.{sdk => jsdk}
  * @param id unique ID of a group within a segment. If None, the server will assign an ID.
  * @param name human readable name of the group. Does not need to be unique.
  * @param addAsMember whether the creating user should be added to the group's membership (in addition to being a group admin)
+ * @param needsRotation if true, the group will be marked as needing its private key rotated.
  */
 case class GroupCreateOpts(
   id: Option[GroupId],
   name: Option[GroupName],
-  addAsMember: Boolean
+  addAsMember: Boolean,
+  needsRotation: Boolean
 ) {
   private[sdk] def toJava[F[_]](implicit syncF: Sync[F]): F[jsdk.GroupCreateOpts] =
     for {
       javaId   <- id.traverse(_.toJava).map(_.orNull)
       javaName <- name.traverse(_.toJava).map(_.orNull)
-    } yield jsdk.GroupCreateOpts.create(javaId, javaName, addAsMember)
+    } yield jsdk.GroupCreateOpts.create(javaId, javaName, addAsMember, needsRotation)
 }
 
 object GroupCreateOpts {
-  def apply(): GroupCreateOpts = GroupCreateOpts(None, None, true)
-  def apply(name: GroupName): GroupCreateOpts = GroupCreateOpts(None, Some(name), true)
-  def apply(id: GroupId): GroupCreateOpts = GroupCreateOpts(Some(id), None, true)
-  def apply(id: GroupId, name: GroupName): GroupCreateOpts = GroupCreateOpts(Some(id), Some(name), true)
+  def apply(): GroupCreateOpts = GroupCreateOpts(None, None, true, false)
+  def apply(name: GroupName): GroupCreateOpts = GroupCreateOpts(None, Some(name), true, false)
+  def apply(id: GroupId): GroupCreateOpts = GroupCreateOpts(Some(id), None, true, false)
+  def apply(id: GroupId, name: GroupName): GroupCreateOpts = GroupCreateOpts(Some(id), Some(name), true, false)
 }

--- a/src/test/scala/ironoxide/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/FullIntegrationTest.scala
@@ -88,7 +88,8 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
   "Group Create" should {
     "Create valid group" in {
       val name = GroupName("a name")
-      val groupCreateResult = sdk.groupCreate(GroupCreateOpts(validGroupId, name)).attempt.unsafeRunSync.value
+      val groupCreateResult =
+        sdk.groupCreate(GroupCreateOpts(Some(validGroupId), Some(name), true, true)).attempt.unsafeRunSync.value
 
       groupCreateResult.id.id shouldBe validGroupId.id
       groupCreateResult.name.get.name shouldBe name.name
@@ -96,7 +97,7 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
       groupCreateResult.isMember shouldBe true
       groupCreateResult.created should not be null
       groupCreateResult.lastUpdated shouldBe groupCreateResult.created
-      groupCreateResult.needsRotation.value shouldBe false
+      groupCreateResult.needsRotation.value shouldBe true
     }
   }
 
@@ -190,7 +191,7 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
       groupGetResult.memberList.value shouldBe List(primaryTestUserId)
       groupGetResult.created should not be null
       groupGetResult.lastUpdated should be > groupGetResult.created
-      groupGetResult.needsRotation.value shouldBe false
+      groupGetResult.needsRotation.value shouldBe true
     }
     "Fail for invalid group id" in {
       val maybeGroupGetResult = sdk.groupGetMetadata(GroupId("tsp")).attempt.unsafeRunSync


### PR DESCRIPTION
- Add `needsRotation` to `GroupCreateOpts`, default is `false`
- Locked tests to staging as that's what the tests assume

Merging into feature branch while catching up with ironoxide 0.14.0
Can depend on ironoxide-java 0.8.0 once catch-up is done