### PR TITLE
Add tryInitialize to help Future consumers

### DIFF
--- a/src/main/scala/com/ironcorelabs/IronSdkFuture.scala
+++ b/src/main/scala/com/ironcorelabs/IronSdkFuture.scala
@@ -3,6 +3,7 @@ package com.ironcorelabs.scala.sdk
 import scala.concurrent.Future
 import scodec.bits.ByteVector
 import cats.effect.IO
+import scala.util.Try
 
 case class IronSdkFuture(underlying: IronSdk[IO]) extends IronSdk[Future] {
 
@@ -92,10 +93,14 @@ case class IronSdkFuture(underlying: IronSdk[IO]) extends IronSdk[Future] {
 }
 
 object IronSdkFuture {
-  def initialize(deviceContext: DeviceContext): Future[IronSdk[Future]] =
+
+  def tryInitialize(deviceContext: DeviceContext): Try[IronSdkFuture] =
+    IronSdk.tryInitialize[IO](deviceContext).map(IronSdkFuture(_))
+
+  def initialize(deviceContext: DeviceContext): Future[IronSdkFuture] =
     IronSdk.initialize[IO](deviceContext).map(IronSdkFuture(_)).unsafeToFuture
 
-  def initializeAndRotate(deviceContext: DeviceContext, password: String): Future[IronSdk[Future]] =
+  def initializeAndRotate(deviceContext: DeviceContext, password: String): Future[IronSdkFuture] =
     IronSdk.initializeAndRotate[IO](deviceContext, password).map(IronSdkFuture(_)).unsafeToFuture
 
   def userCreate[F[_]](jwt: String, password: String, options: UserCreateOpts): Future[UserCreateResult] =

--- a/src/test/scala/ironoxide/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/FullIntegrationTest.scala
@@ -56,6 +56,15 @@ class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues 
 
   val sdk = IronSdk.initialize[IO](deviceContext).unsafeRunSync
 
+  "IronSdk.tryInitialize" should {
+    "succeed for good values" in {
+      IronSdk.tryInitialize[IO](deviceContext) shouldBe 'success
+    }
+    "fail for bad values" in {
+      IronSdk.tryInitialize[IO](deviceContext.copy(devicePrivateKey = PrivateKey(ByteVector.empty))) shouldBe 'failure
+    }
+  }
+
   "DeviceCreateOpts" should {
     "create with empty DeviceName" in {
       val deviceName = ju.Optional.empty[jsdk.DeviceName]


### PR DESCRIPTION
When working with Future, it stinks to have initialize return the Future type because you then have to await it. The common type to use instead is Try. 