### PR TITLE
Update README with correct ironoxide-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![scaladoc](https://javadoc-badge.appspot.com/com.ironcorelabs/ironoxide-scala_2.12.svg?label=scaladoc)](https://javadoc-badge.appspot.com/com.ironcorelabs/ironoxide-scala_2.12)
 
-SDK for using IronCore Labs from Scala server side applications. This library wraps [ironoxide-java](https://github.com/IronCoreLabs/ironoxide-swig-bindings#ironoxide-swig-bindings)
+SDK for using IronCore Labs from Scala server side applications. This library wraps [IronOxide-Java](https://github.com/IronCoreLabs/ironoxide-swig-bindings/tree/master/java)
 with more Scala friendly interfaces and types. It presents two top level APIs:
 
 - [`IO`](https://typelevel.org/cats-effect/) based
@@ -10,16 +10,16 @@ with more Scala friendly interfaces and types. It presents two top level APIs:
 
 ## Installation
 
-This project is [published to Maven central](https://search.maven.org/artifact/com.ironcorelabs/ironoxide-scala_2.12).
+This project is published to [Maven central](https://search.maven.org/artifact/com.ironcorelabs/ironoxide-scala_2.12).
 
-You'll also need to follow the library setup instructions for [ironoxide-java](https://github.com/IronCoreLabs/ironoxide-swig-bindings#library) to ensure
+You'll also need to follow the library setup instructions for [IronOxide-Java](https://github.com/IronCoreLabs/ironoxide-swig-bindings/tree/master/java#library) to ensure
 you have the proper binary compiled and loaded.
 
 Below you'll find a link of the ironoxide-scala version with which native component you need:
 
 | ironoxide-scala | ironoxide-java                                                                         |
 | --------------- | -------------------------------------------------------------------------------------- |
-| 0.14.0          | [0.14.0](https://github.com/IronCoreLabs/ironoxide-swig-bindings/releases/tag/v0.14.0) |
+| 0.14.0          | [0.14.2](https://github.com/IronCoreLabs/ironoxide-swig-bindings/releases/tag/v0.14.2) |
 | 0.13.0          | [0.13.2](https://github.com/IronCoreLabs/ironoxide-swig-bindings/releases/tag/v0.13.0) |
 | 0.12.1          | [0.12.1](https://github.com/IronCoreLabs/ironoxide-swig-bindings/releases/tag/v0.12.1) |
 | 0.12.0          | [0.12.0](https://github.com/IronCoreLabs/ironoxide-swig-bindings/releases/tag/v0.12.0) |


### PR DESCRIPTION
Now that ironoxide-java 0.14.2 is out and working, I fixed the dead link to 0.14.0.