### PR TITLE
Upgrade to Cats Effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.ironcorelabs"
-ThisBuild / scalaVersion := "2.12.11"
+ThisBuild / scalaVersion := "2.12.13"
 
 lazy val root = (project in file(".")).settings(
   name := "ironoxide-scala",
@@ -27,7 +27,7 @@ lazy val root = (project in file(".")).settings(
   libraryDependencies ++= Seq(
     "org.scodec"       %% "scodec-bits"    % "1.1.14",
     "com.ironcorelabs" % "ironoxide-java"  % "0.14.0",
-    "org.typelevel"    %% "cats-effect"    % "2.1.2",
+    "org.typelevel"    %% "cats-effect"    % "3.3.11",
     "com.ironcorelabs" %% "cats-scalatest" % "3.0.5" % Test,
     "org.scalatest"    %% "scalatest"      % "3.1.1" % Test
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.ironcorelabs"
-ThisBuild / scalaVersion := "2.12.13"
+ThisBuild / scalaVersion := "2.12.15"
 
 lazy val root = (project in file(".")).settings(
   name := "ironoxide-scala",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.6.2

--- a/src/main/scala/ironoxide/v1/IronOxide.scala
+++ b/src/main/scala/ironoxide/v1/IronOxide.scala
@@ -10,6 +10,7 @@ import ironoxide.v1.user._
 import scala.concurrent.duration.Duration
 import scala.util.Try
 import scodec.bits.ByteVector
+import cats.effect.unsafe.implicits.global
 
 /**
  * Ability to make authenticated requests to the IronCore API. Instantiated with the details

--- a/src/main/scala/ironoxide/v1/IronOxideAdvancedFuture.scala
+++ b/src/main/scala/ironoxide/v1/IronOxideAdvancedFuture.scala
@@ -5,6 +5,7 @@ import ironoxide.v1.common.{EncryptedData, EncryptedDeks}
 import ironoxide.v1.document._
 import scala.concurrent.Future
 import scodec.bits.ByteVector
+import cats.effect.unsafe.implicits.global
 
 case class IronOxideAdvancedFuture(underlying: IronOxideAdvanced[IO]) extends IronOxideAdvanced[Future] {
 

--- a/src/main/scala/ironoxide/v1/IronOxideFuture.scala
+++ b/src/main/scala/ironoxide/v1/IronOxideFuture.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.Future
 import scala.util.Try
 import scodec.bits.ByteVector
+import cats.effect.unsafe.implicits.global
 
 case class IronOxideFuture(underlying: IronOxide[IO]) extends IronOxide[Future] {
 

--- a/src/test/scala/ironoxide/v1/FullIntegrationTest.scala
+++ b/src/test/scala/ironoxide/v1/FullIntegrationTest.scala
@@ -13,6 +13,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scodec.bits.ByteVector
+import cats.effect.unsafe.implicits.global
 
 class FullIntegrationTest extends AsyncWordSpec with Matchers with EitherValues with OptionValues {
   try {


### PR DESCRIPTION
Hi @coltfred, I'm working with the dBio group at Harvard using IronCore for our thesis project.

I saw a quick fix to get this repo up to Cats Effect 3 in my own fork and figured it might be of interest.

I did not however convert any of the existing code to the not use the `unsafe*` methods in static parts of the program, which CE3 does not allow. They provide an unsafe global runtime to make it work, but it's more of a stop-gap than a fix. 

I see how this library uses unsafe conversions to Future and Try in a couple places, and for unit tests. There should be a couple ways to still do this without needing the global runtime available. 